### PR TITLE
Add a Makefile to ease quick runs on a new machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+dev: install-depends migrate
+	python3 manage.py runserver
+
+install-depends:
+	pip3 install -r requirements.txt
+
+migrate:
+	python3 manage.py makemigrations
+	python3 manage.py showmigrations
+	python3 manage.py migrate
+
+createsuperuser:
+	python3 manage.py createsuperuser


### PR DESCRIPTION
The targets are intentionally only relying on pip and python. So it's assuming the user already has those installed.